### PR TITLE
Pretty print Eclipse XML files

### DIFF
--- a/src/main/scala/SbtEclipsePlugin.scala
+++ b/src/main/scala/SbtEclipsePlugin.scala
@@ -18,12 +18,12 @@
 
 package com.typesafe.sbteclipse
 
-import java.io.{ File, FileWriter, StringWriter }
+import java.io.{ File, FileWriter }
 import sbt._
 import sbt.complete._
 import sbt.complete.Parsers._
 import sbt.CommandSupport.logger
-import scala.xml.{ Elem, Node, NodeSeq, XML, PrettyPrinter, Unparsed }
+import scala.xml.{ Node, NodeSeq, XML, PrettyPrinter }
 import scalaz.{ Failure, NonEmptyList, Success, Validation }
 import scalaz.Scalaz._
 


### PR DESCRIPTION
I often have to view these 2 eclipse files in a diff tool before committing them for use by other developers and formatting goes a long way to helping with verifying what changed.  In the PrettyPrinter settings, I used the Eclipse-style formatting of 2 spaces for an indent.  Also using a width of 500 effectively turns off any right-margin.  I can provide a patch file if you prefer (tried to squash the 3 commits but it wouldn't allow it without a previous commit).

Andrew Goodnough
Lead Programmer
Wisconsin Supreme Court
