### PR TITLE
Use workspace default JRE

### DIFF
--- a/src/main/scala/com/typesafe/sbteclipse/SbtEclipsePlugin.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/SbtEclipsePlugin.scala
@@ -233,7 +233,7 @@ object SbtEclipse {
       libEntries ++
       projectDependencyEntries ++
       <classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-      <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+      <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
       <classpathentry kind="output" path={ outputPath(compileDirectories.clazz) }/>
     }</classpath>
   }


### PR DESCRIPTION
some user maybe starting switch to jdk 1.7. let the user set JRE version in eclipse would be better.

the code is my original work and these code license to the sbteclipse project under the project’s open source license.
