### PR TITLE
Implemented correct handling of Scala Compiler dependency.

### DIFF
--- a/src/main/scala/com/typesafe/sbteclipse/SbtEclipsePlugin.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/SbtEclipsePlugin.scala
@@ -215,6 +215,10 @@ object SbtEclipse {
       }
     }
     def libEntries = libraries flatMap {
+      //Scala compiler (and library) are treated as special kind of dependencies in Scala IDE
+      case Library(file, _) if file.getName == "scala-compiler.jar" =>
+        logDebug("Creating lib entry for Scala compiler.")
+        <classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
       case Library(Path(binary), Some(Path(sources))) =>
         logDebug("""Creating lib entry with source attachment for dependency "%s".""" format binary)
         <classpathentry kind="lib" path={ binary } sourcepath={ sources }/>


### PR DESCRIPTION
Both Scala library and Scala compiler are treated in
a special way by Scala IDE and .classpath file must
be configured differently for those two dependencies.

So far only Scala library has been treated in a special
way in sbteclipse plug-in. Added the same kind of logic
for Scala compiler.

Fixes #44.

Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
