### PR TITLE
add new option to use project-id as eclipse project name

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -276,7 +276,10 @@ private object Eclipse {
   // Getting and transforming mandatory settings and task results
 
   def name(ref: Reference, state: State): Validation[String] =
-    setting(Keys.name in ref, state)
+    if (setting(EclipseKeys.useProjectId in ref, state).fold(_ => false, id))
+      setting(Keys.thisProject in ref, state) map (_.id)
+    else
+      setting(Keys.name in ref, state)
 
   def buildDirectory(state: State): Validation[File] =
     setting(Keys.baseDirectory in ThisBuild, state)

--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
@@ -25,4 +25,6 @@ private object EclipseOpts {
   val SkipParents = "skip-parents"
 
   val WithSource = "with-source"
+
+  val UseProjectId = "use-project-id"
 }

--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -65,6 +65,11 @@ trait EclipsePlugin {
       "Download and link sources for library dependencies?"
     )
 
+    val useProjectId: SettingKey[Boolean] = SettingKey(
+      prefix(UseProjectId),
+      "Use the sbt project id as the Eclipse project name?"
+    )
+
     @deprecated("Use classpathTransformerFactories instead!", "2.1.0")
     val classpathEntryTransformerFactory: SettingKey[EclipseTransformerFactory[Seq[EclipseClasspathEntry] => Seq[EclipseClasspathEntry]]] = SettingKey(
       prefix("classpathEntryTransformerFactory"),

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/build.sbt
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/build.sbt
@@ -16,6 +16,20 @@ TaskKey[Unit]("verify-project-xml") <<= baseDirectory map { dir =>
     error("Expected .project to contain name '%s', but was '%s'!".format("sbteclipse-test", name))
 }
 
+TaskKey[Unit]("verify-project-xml-subd") <<= baseDirectory map { dir =>
+  val projectDescription = XML.loadFile(dir / "sub" / "subd" / ".project")
+  val name = (projectDescription \ "name").text
+  if (name != "subd-id")
+    error("Expected .project to contain name '%s', but was '%s'!".format("subd-id", name))
+}
+
+TaskKey[Unit]("verify-project-xml-sube") <<= baseDirectory map { dir =>
+  val projectDescription = XML.loadFile(dir / "sub" / "sube" / ".project")
+  val name = (projectDescription \ "name").text
+  if (name != "sube")
+    error("Expected .project to contain name '%s', but was '%s'!".format("sube", name))
+}
+
 TaskKey[Unit]("verify-classpath-xml-root") <<= baseDirectory map { dir =>
   val classpath = XML.loadFile(dir / ".classpath")
   if ((classpath \ "classpathentry") != (classpath \ "classpathentry").distinct)

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/project/Build.scala
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/project/Build.scala
@@ -32,7 +32,7 @@ object Build extends Build {
       EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE16),
       EclipseKeys.withSource := true
     ),
-    aggregate = Seq(suba, subb, subc)
+    aggregate = Seq(suba, subb, subc, subd, sube)
   )
 
   lazy val suba = Project(
@@ -111,4 +111,21 @@ object Build extends Build {
       )
     )
   }
+
+  lazy val subd = Project(
+    id = "subd-id",
+    base = new File("sub/subd"),
+    settings = Project.defaultSettings ++ Seq(
+      name := "subd",
+      EclipseKeys.useProjectId := true
+    )
+  )
+
+  lazy val sube = Project(
+    id = "sube-id",
+    base = new File("sub/sube"),
+    settings = Project.defaultSettings ++ Seq(
+      name := "sube"
+    )
+  )
 }

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/test
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/test
@@ -3,6 +3,8 @@
 $ mkdir target/scala-2.9.1/src_managed/main
 > eclipse skip-parents=false
 > verify-project-xml
+> verify-project-xml-subd
+> verify-project-xml-sube
 > verify-classpath-xml-root
 > verify-classpath-xml-sub
 > verify-classpath-xml-suba


### PR DESCRIPTION
This was mentioned on the mailing list: https://groups.google.com/d/topic/simple-build-tool/S46H3BQdLAw/discussion

The idea here is to add a new setting, called `useProjectId`.  When `useProjectId` is present and set to `true`, then the generated Eclipse `.project` file will specify a project name based on the sbt project id, rather than the sbt project name.

The use case for this is caused by Eclipse's inability to open multiple projects of the same name within a workspace.  I often work with sbt projects which are composed of multiple versions of a project, all with the same module name, but with different revisions.

For example, I might have subprojects myproject-1.0, myproject-2.0, etc.  If I generate Eclipse configuration for these projects they will both have the name `myproject`, which prevents me from opening both of them in Eclipse at the same time.  Adding the `useProjectId` setting will cause the Eclipse project names to be distinct (based on the `id` of the sbt projects), so I can work with both of them in the same workspace.
