### PR TITLE
add resolver needed for sbt-release with 0.11.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
+// needed to resolve sbt-release in SBT versions before 0.12.x
+resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.5")
 


### PR DESCRIPTION
Currently sbteclipse won't build when using sbt-launch.jar version 0.11.3.  The following errors result when launching sbt:

```
[warn]  module not found: com.github.gseitz#sbt-release;0.5
[warn] ==== typesafe-ivy-releases: tried
[warn]   http://repo.typesafe.com/typesafe/ivy-releases/com.github.gseitz/sbt-release/scala_2.9.1/sbt_0.11.3/0.5/ivys/ivy.xml
[warn] ==== local: tried
[warn]   /home/james/.ivy2/local/com.github.gseitz/sbt-release/scala_2.9.1/sbt_0.11.3/0.5/ivys/ivy.xml
[warn] ==== public: tried
[warn]   http://repo1.maven.org/maven2/com/github/gseitz/sbt-release_2.9.1_0.11.3/0.5/sbt-release-0.5.pom

// lines snipped //

[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: com.github.gseitz#sbt-release;0.5: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Some unresolved dependencies have extra attributes.  Check that these dependencies exist with the requested attributes.
[warn]      com.github.gseitz:sbt-release:0.5 (sbtVersion=0.11.3, scalaVersion=2.9.1)
[warn] 
[error] {file:/home/james/workspace/sbteclipse/project/}default-5d2ea1/*:update: sbt.ResolveException: unresolved dependency: com.github.gseitz#sbt-release;0.5: not found
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? q
```

The following comment from the [sbt-release](https://github.com/sbt/sbt-release) readme indicates that the resolver is explicitly needed:

```
// This resolver declaration is added by default in SBT 0.12.x
```

To resolve this, I added the resolver to `project/plugins.sbt`.
