### PR TITLE
fix broken test in linux by ensuring deletion of */.settings*

### DIFF
--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/01-structure/test
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/01-structure/test
@@ -1,7 +1,7 @@
 # Default settings (skip-parents=true)
 $ exec find . -path "*.classpath*" -delete
 $ exec find . -path "*.project*" -delete
-$ exec find . -path "*/.settings" -delete
+$ exec find . -path "*/.settings*" -delete
 $ exec find . -path "*/touch-pre-task" -delete
 > eclipse
 $ absent .classpath
@@ -27,7 +27,7 @@ $ absent sub/subc/touch-pre-task
 # skip-parents=false
 $ exec find . -path "*.classpath*" -delete
 $ exec find . -path "*.project*" -delete
-$ exec find . -path "*/.settings" -delete
+$ exec find . -path "*/.settings*" -delete
 > eclipse skip-parents=false
 $ exists .classpath
 $ exists .project


### PR DESCRIPTION
The test `01-structure` was failing under Linux, but passing under OSX.  This was due to the differences between GNU `find` and OSX `find`.  In Linux, `find -delete` returns non-zero for an error, but in OSX always returns success.

Since the command `find . -path "*/.settings" -delete` fails when `.settings` has children, OSX was getting a (false) success while Linux was getting a (correct) failure.

I updated the `find -delete` command to make sure that `.settings` as well as its children definitely get deleted.

Here was the failing output from `sbt "show scripted"`:

```
Running sbteclipse / 01-structure
find: cannot delete `./sub/subb/.settings': Directory not empty

// lines snipped //

[error] x sbteclipse / 01-structure
xsbt.test.TestException: {line 30}  Command failed

// lines snipped //

Caused by: java.lang.RuntimeException: Nonzero exit value (1)
```
