### PR TITLE
update tests to use current version (2.2.0-SNAPSHOT)

### DIFF
--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/00-defaults/project/plugins.sbt
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/00-defaults/project/plugins.sbt
@@ -1,2 +1,2 @@
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0-SNAPSHOT")

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/01-structure/project/plugins.sbt
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/01-structure/project/plugins.sbt
@@ -1,2 +1,2 @@
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0-SNAPSHOT")

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/project/plugins.sbt
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/project/plugins.sbt
@@ -1,2 +1,2 @@
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0-SNAPSHOT")


### PR DESCRIPTION
Replace _2.1.0-SNAPSHOT_ with _2.2.0-SNAPSHOT_ in the test configurations to test against the current version of sbteclipse (as specified by [version.sbt](https://github.com/typesafehub/sbteclipse/blob/master/version.sbt)).
