### PR TITLE
For the more impatient

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ For the impatient
 
 - sbteclipse requires sbt 0.11.3-2 or 0.12!
 
-- Add sbteclipse to your plugin definition file. You can use either the global one at ~/.sbt/plugins/plugins.sbt or the project-specific one at PROJECT_DIR/project/plugins.sbt::
+- Add sbteclipse to your plugin definition file. You can use either the global one at *~/.sbt/plugins/plugins.sbt* or the project-specific one at *PROJECT_DIR/project/plugins.sbt*::
 
     addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
 


### PR DESCRIPTION
Hi, 

There are quite few clicks through into the docs before you actually find out where the sbt plugins file lives. I thought it might make it a little quicker for first-timers if the "for the impatient" quickstart told them where they could paste the plugin definition code. 
