### PR TITLE
Patches to also support generating NetBeans's sbt project .classpath_nb file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 .cache
 .classpath
 .project
+.classpath_nb
 .scala_dependencies
 .settings
 .target/

--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
@@ -27,4 +27,6 @@ private object EclipseOpts {
   val WithSource = "with-source"
 
   val UseProjectId = "use-project-id"
+
+  val GenNetBeans = "gen-netbeans"
 }

--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -150,32 +150,49 @@ trait EclipsePlugin {
 
   sealed trait EclipseClasspathEntry {
     def toXml: Node
+    def toXmlNetBeans: Node
   }
 
   object EclipseClasspathEntry {
 
-    case class Src(path: String, output: String) extends EclipseClasspathEntry {
+    case class Src(scope: String, path: String, output: String) extends EclipseClasspathEntry {
       override def toXml = <classpathentry kind="src" path={ path } output={ output }/>
+      override def toXmlNetBeans = <classpathentry kind="src" path={ path } output={ output } scope={ scope }/>
     }
 
-    case class Lib(path: String, sourcePath: Option[String] = None) extends EclipseClasspathEntry {
+    case class Lib(scope: String, path: String, sourcePath: Option[String] = None) extends EclipseClasspathEntry {
       override def toXml =
         sourcePath.foldLeft(<classpathentry kind="lib" path={ path }/>)((xml, sp) =>
           xml % Attribute("sourcepath", Text(sp), Null)
         )
+      override def toXmlNetBeans =
+        sourcePath.foldLeft(<classpathentry kind="lib" path={ path } scope={ scope }/>)((xml, sp) =>
+          xml % Attribute("sourcepath", Text(sp), Null)
+        )
     }
 
-    case class Project(name: String) extends EclipseClasspathEntry {
+    case class Project(name: String, path: String, output: String) extends EclipseClasspathEntry {
       override def toXml =
         <classpathentry kind="src" path={ "/" + name } exported="true" combineaccessrules="false"/>
+      override def toXmlNetBeans =
+        <classpathentry kind="src" path={ name } exported="true" combineaccessrules="false" base={ path } output={ output }/>
+    }
+
+    case class AggProject(name: String, path: String) extends EclipseClasspathEntry {
+      override def toXml =
+        <classpathentry kind="agg" path={ "/" + name }/>
+      override def toXmlNetBeans =
+        <classpathentry kind="agg" path={ name } base={ path }/>
     }
 
     case class Con(path: String) extends EclipseClasspathEntry {
       override def toXml = <classpathentry kind="con" path={ path }/>
+      override def toXmlNetBeans = <classpathentry kind="con" path={ path }/>
     }
 
     case class Output(path: String) extends EclipseClasspathEntry {
       override def toXml = <classpathentry kind="output" path={ path }/>
+      override def toXmlNetBeans = <classpathentry kind="output" path={ path }/>
     }
   }
 


### PR DESCRIPTION
Hi,

I'm the author of NetBeans support for Scala. During working on sbt integration with NetBeans, I found your great code, and decided to work based on it. Here's the patches that will get NetBeans sbt project descriptor file - ".classpath_nb" to be generated, by adding argument "gen-netbeans=true". 

The major patching work can be summarized as:
1. Scoped classpath entry;
2. A new command argument "gen-netebans", which will create file .classpath_nb instead of .classpath
3. Generate aggregate projects

This work should be compatible with your current work, ie. generate the same result for eclipse.

Cheers,
-Caoyuan Deng
