### PR TITLE
Fixes #136 - Support for non-relative source directories.

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -229,7 +229,7 @@ private object Eclipse extends EclipseSDTConfig {
               <link>
                 <name>{ name }</name>
                 <type>2</type>
-                <location>{ location.getCanonicalPath }</location>
+                <location>{ location.getCanonicalPath.replaceAll("\\\\", "/") }</location>
               </link>
           }
         }


### PR DESCRIPTION
FIXES #136 (biggest pain I've had using sbt-eclipse so far, which is to say I haven't had much pain.)
- Adds a splitting function to srcDirectories when generating project files.
- Generate link name based on _absolute_ canonical path of a resource
- Adds additional logic to normalize filenames for ".."
