### PR TITLE
Support -Xmax-classfile-name scalac option

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseSDTConfig.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseSDTConfig.scala
@@ -42,6 +42,7 @@ private trait EclipseSDTConfig {
     ColonSeparated("Xplugin-disable"),
     ColonSeparated("Xplugin-require"),
     TakesArg("Xpluginsdir"),
+    TakesArg("Xmax-classfile-name"),
 
     Flag("Yno-generic-signatures"),
     Flag("Yno-imports"),


### PR DESCRIPTION
It appears that sbteclipse ignores -Xmax-classfile-name scalac options.  This option is necessary when people are on systems that have filename length limits, such as this Play user:

https://github.com/playframework/playframework/issues/1379
