### PR TITLE
Compiled with Scalaz 7.0.2

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,9 @@ object Build extends Build {
     "sbteclipse-core",
     file("sbteclipse-core"),
     settings = commonSettings ++ Seq(
-      libraryDependencies ++= Seq("org.scalaz" %% "scalaz-core" % "6.0.4")
+      libraryDependencies ++= Seq(
+       "org.scalaz"  %% "scalaz-core"  % "7.0.2",
+       "org.scalaz" %% "scalaz-effect" % "7.0.2")
     )
   )
 


### PR DESCRIPTION
I compiled the plugin with Scalaz 7.0.2 and things [seems to be working](http://bit.ly/15mK3WQ).

However I am not sure that my changes reflect the best Scalaz practices:
- using `toList` every time `sequence` is needed (to get the proper implicits that are not accessible with `Seq`)
- defining `io[T](t: => T): IO[T] = scalaz.effect.IO(t)`. There is maybe such an existing function in Scalaz7?
