### PR TITLE
Handle withSources() on sbt dependencies

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -420,7 +420,7 @@ private object Eclipse extends EclipseSDTConfig {
     withSource: Boolean,
     state: State)(
       configuration: Configuration): Validation[Seq[Lib]] = {
-    def moduleToFile(key: TaskKey[UpdateReport], p: (Artifact, File) => Boolean = (_, _) => true) =
+    def moduleToFile(key: TaskKey[UpdateReport], p: (Artifact, File) => Boolean = (artifact, _) => artifact.classifier === None) =
       evaluateTask(key in configuration, ref, state) map { updateReport =>
         val moduleToFile =
           for {

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/build.sbt
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/build.sbt
@@ -1,0 +1,27 @@
+import scala.xml.XML
+
+EclipseKeys.withSource := true
+
+organization := "com.typesafe.sbteclipse"
+
+name := "sbteclipse-test"
+
+version := "1.2.3"
+
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.0.1"
+
+libraryDependencies += "biz.aQute" % "bndlib" % "1.50.0" withSources()
+
+libraryDependencies += "org.specs2" %% "specs2" % "2.1.1" % "test" withSources()
+
+TaskKey[Unit]("verify-classpath-xml") <<= baseDirectory map { dir =>
+  val home = System.getProperty("user.home")
+  val classpath = XML.loadFile(dir / ".classpath")
+  // lib entries with sources
+  def verifySrcClasspathEntry(libPath: String, srcPath: String) =
+    if (!(classpath.child contains <classpathentry kind="lib" path={ libPath } sourcepath={ srcPath } />))
+      error("""Expected .classpath of project to contain <classpathentry kind="lib" path="%s" sourcepath="%s" />: %s""".format(libPath, srcPath, classpath))
+  verifySrcClasspathEntry(home + "/.ivy2/cache/ch.qos.logback/logback-classic/jars/logback-classic-1.0.1.jar", home + "/.ivy2/cache/ch.qos.logback/logback-classic/srcs/logback-classic-1.0.1-sources.jar")
+  verifySrcClasspathEntry(home + "/.ivy2/cache/biz.aQute/bndlib/jars/bndlib-1.50.0.jar", home + "/.ivy2/cache/biz.aQute/bndlib/srcs/bndlib-1.50.0-sources.jar")
+  verifySrcClasspathEntry(home + "/.ivy2/cache/org.specs2/specs2_2.10/jars/specs2_2.10-2.1.1.jar", home + "/.ivy2/cache/org.specs2/specs2_2.10/srcs/specs2_2.10-2.1.1-sources.jar")
+}

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/project/plugins.sbt
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % pluginVersion)
+}

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/src/main/scala/Main.scala
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+object Main

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/test
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/03-sbt-dependency-withsources/test
@@ -1,0 +1,4 @@
+> clean
+> compile
+> eclipse skip-parents=false
+> verify-classpath-xml


### PR DESCRIPTION
Declaring withSources() on a sbt dependency no longer prevents the
source from being attached when the sbteclipse withSource option is set

fixes #161
