### PR TITLE
Makes erasing the scala-(compiler|library) on classpath optional

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
@@ -29,4 +29,6 @@ private object EclipseOpts {
   val WithJavadoc = "with-javadoc"
 
   val UseProjectId = "use-project-id"
+
+  val WithBundledScalaContainers = "with-bundled-scala-containers"
 }

--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -70,6 +70,11 @@ trait EclipsePlugin {
       "Download and link javadoc for library dependencies?"
     )
 
+    val withBundledScalaContainers: SettingKey[Boolean] = SettingKey(
+      prefix(WithBundledScalaContainers),
+      "Let the generated project use the bundled Scala library of the ScalaIDE plugin"
+    )
+
     val useProjectId: SettingKey[Boolean] = SettingKey(
       prefix(UseProjectId),
       "Use the sbt project id as the Eclipse project name?"


### PR DESCRIPTION
The default is true and preserves old behavior. This is needed for ScalaIDE's
use of Xsource.

review by @skyluc, @jsuereth
