### PR TITLE
Fix for linkedResources under win32.

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -247,7 +247,7 @@ private object Eclipse extends EclipseSDTConfig {
           sourceLinks map {
             case (location, name, _) =>
               <link>
-                <name>{ name }</name>
+                <name>{ name.replaceAll("^[A-Z]:", "") }</name>
                 <type>2</type>
                 <location>{ location.getCanonicalPath.replaceAll("\\\\", "/") }</location>
               </link>


### PR DESCRIPTION
Simply remove drive letters to ensure invalid project names are not generated.
There are likely other characters that are not accepted by eclipse that could conceivably be included by crazy characters in a path, but this fixes the basic problem.
