### PR TITLE
Use a Scalaz construct that hasn't been removed in 7.1

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -416,7 +416,7 @@ private object Eclipse extends EclipseSDTConfig {
     }
     def dirs(values: ValueSet, key: SettingKey[Seq[File]]): Validation[List[(sbt.File, java.io.File)]] =
       if (values subsetOf createSrc)
-        (setting(key in (ref, configuration), state) <**> classDirectory)((sds, cd) => sds.toList map (_ -> cd))
+        (setting(key in (ref, configuration), state) |@| classDirectory)((sds, cd) => sds.toList map (_ -> cd))
       else
         scalaz.Validation.success(Nil)
     List(


### PR DESCRIPTION
See:

   https://github.com/scalaz/scalaz/commits/series/7.2.x/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
   https://github.com/scalaz/scalaz/commit/14c5ba4943e57ce14a4070863353bc8259772b2b

This commit doesn't yet upgrade Scalaz to 7.1.x, but does allow us
to do so in our community build that include sbteclipse.
