### PR TITLE
Swap projectDependencies/externalDependencies order to make the generate...

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -312,8 +312,8 @@ private object Eclipse extends EclipseSDTConfig {
       linkEntries <- srcLinkEntriesIoSeq.toList.sequence
     ) yield {
       val entries = srcEntries ++ linkEntries ++
-        (externalDependencies map libEntry(buildDirectory, baseDirectory, relativizeLibs, state)) ++
         (projectDependencies map EclipseClasspathEntry.Project) ++
+        (externalDependencies map libEntry(buildDirectory, baseDirectory, relativizeLibs, state)) ++
         (Seq(jreContainer) map EclipseClasspathEntry.Con) ++
         (Seq("bin") map EclipseClasspathEntry.Output)
       <classpath>{ classpathEntryTransformer(entries) map (_.toXml) }</classpath>


### PR DESCRIPTION
...d eclipse .classpath more consistent with native sbt classpath dependency order

Partial fix for #226 a complete audit looks like a lot of work :)  This will at least fix the project dependency classpath issue
