### PR TITLE
Remove scalariform and scala-xml

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ lazy val root = (project in file("."))
         s
       },
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" %% "scala-xml"     % "2.1.0",
         "org.scalaz"             %% "scalaz-core"   % "7.2.34",
         "org.scalaz"             %% "scalaz-effect" % "7.2.34",
         "org.scalatest"          %% "scalatest"     % "3.2.3" % "test"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
I don't think we need to pull scala-xml, since it comes with the scala compiler and this is a sbt plugin, so I guess the scala compiler should alway be on the classpath anyway.