### PR TITLE
Implement JDT compiler settings writing

### DIFF
--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
@@ -22,6 +22,8 @@ private object EclipseOpts {
 
   val ExecutionEnvironment = "execution-environment"
 
+  val JDTMode = "jdt-mode"
+
   val SkipParents = "skip-parents"
 
   val WithSource = "with-source"

--- a/src/sbt-test/sbteclipse/08-jdt-settings/.gitignore
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/.gitignore
@@ -1,0 +1,1 @@
+!.settings

--- a/src/sbt-test/sbteclipse/08-jdt-settings/b/expected
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/b/expected
@@ -1,0 +1,3 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8

--- a/src/sbt-test/sbteclipse/08-jdt-settings/build.sbt
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/build.sbt
@@ -1,0 +1,92 @@
+
+val check = TaskKey[Unit]("check") := {
+  import java.util.Properties
+  import java.io.FileInputStream
+  import scala.collection.JavaConverters._
+
+  val s: TaskStreams = streams.value
+  val expectedFile = baseDirectory.value / "expected"
+  val resultFile = baseDirectory.value / ".settings" / "org.eclipse.jdt.core.prefs"
+
+  if (expectedFile.exists()) {
+    val expectedIn = new FileInputStream(expectedFile)
+    val expected =
+      try {
+        val prop = new Properties()
+        prop.load(expectedIn)
+        prop.asScala.toMap
+      } finally {
+        expectedIn.close()
+      }
+
+    val resultIn = new FileInputStream(resultFile)
+    val result =
+      try {
+        val prop = new Properties()
+        prop.load(resultIn)
+        prop.asScala.toMap
+      } finally {
+        resultIn.close()
+      }
+
+    if (expected == result)
+      s.log.info(s"correct data: ${resultFile}")
+    else
+      sys.error("Expected settings to be '%s', but was '%s'!".format(expected, result))
+  }
+}
+
+// ensure org.eclipse.core.resources.prefs will always be generated
+ThisBuild / scalacOptions ++= Seq("-encoding", "utf-8")
+
+// check that no JDT file is generated (default ignore, no runtime defined)
+lazy val projectA = (project in file("a"))
+  .settings(
+    check
+  )
+
+// check that a new and correct JDT file is generated
+lazy val projectB = (project in file("b"))
+  .settings(
+    EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE18),
+    EclipseKeys.jdtMode := EclipseJDTMode.Update,
+    check
+  )
+
+// check that a correct JDT file is is not updated
+lazy val projectC = (project in file("c"))
+  .settings(
+    EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE11),
+    EclipseKeys.jdtMode := EclipseJDTMode.Update,
+    check
+  )
+
+// check that an outdated JDT file is selectively updated
+lazy val projectD = (project in file("d"))
+  .settings(
+    EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE_17),
+    EclipseKeys.jdtMode := EclipseJDTMode.Update,
+    check
+  )
+
+// check that a JDT file is overwritten
+lazy val projectE = (project in file("e"))
+  .settings(
+    EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE11),
+    EclipseKeys.jdtMode := EclipseJDTMode.Overwrite,
+    check
+  )
+
+// check that an JDT file is removed
+lazy val projectF = (project in file("f"))
+  .settings(
+    EclipseKeys.jdtMode := EclipseJDTMode.Remove,
+    check
+  )
+
+// check that an JDT file is default ignored, but written on command
+lazy val projectG = (project in file("g"))
+  .settings(
+    EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE18),
+    check
+  )

--- a/src/sbt-test/sbteclipse/08-jdt-settings/c/.settings/org.eclipse.jdt.core.prefs
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/c/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.compliance=11
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/c/expected
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/c/expected
@@ -1,0 +1,4 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.compliance=11
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/d/.settings/org.eclipse.jdt.core.prefs
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/d/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.compliance=11
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/d/expected
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/d/expected
@@ -1,0 +1,4 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.compliance=17
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/e/.settings/org.eclipse.jdt.core.prefs
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/e/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.compliance=11
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/e/expected
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/e/expected
@@ -1,0 +1,3 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.compliance=11

--- a/src/sbt-test/sbteclipse/08-jdt-settings/f/.settings/org.eclipse.jdt.core.prefs
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/f/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.compliance=11
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/g/.settings/org.eclipse.jdt.core.prefs
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/g/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,1 @@
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/g/expected
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/g/expected
@@ -1,0 +1,1 @@
+dummy.key=abc

--- a/src/sbt-test/sbteclipse/08-jdt-settings/project/plugins.sbt
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.github.sbt" % "sbt-eclipse" % pluginVersion)
+}

--- a/src/sbt-test/sbteclipse/08-jdt-settings/test
+++ b/src/sbt-test/sbteclipse/08-jdt-settings/test
@@ -1,0 +1,62 @@
+# timestamp marker file 
+$ touch marker
+
+$ exists f/.settings/org.eclipse.jdt.core.prefs
+
+> eclipse
+
+> check
+
+$ exists a/.settings/org.eclipse.core.resources.prefs
+-$ exists a/.settings/org.eclipse.jdt.core.prefs
+
+$ exists b/.settings/org.eclipse.jdt.core.prefs
+$ newer b/.settings/org.eclipse.jdt.core.prefs marker
+
+$ exists c/.settings/org.eclipse.jdt.core.prefs
+$ newer marker c/.settings/org.eclipse.jdt.core.prefs
+
+$ exists d/.settings/org.eclipse.jdt.core.prefs
+$ newer d/.settings/org.eclipse.jdt.core.prefs marker
+
+$ exists e/.settings/org.eclipse.jdt.core.prefs
+$ newer e/.settings/org.eclipse.jdt.core.prefs marker
+
+$ exists f/.settings/org.eclipse.core.resources.prefs
+-$ exists f/.settings/org.eclipse.jdt.core.prefs
+
+$ exists g/.settings/org.eclipse.jdt.core.prefs
+$ newer marker g/.settings/org.eclipse.jdt.core.prefs
+
+# test overwrite mode via command arg
+$ touch marker
+> eclipse jdt-mode=Overwrite
+# no runtime defined for a
+-$ exists a/.settings/org.eclipse.jdt.core.prefs
+$ newer b/.settings/org.eclipse.jdt.core.prefs marker
+$ newer c/.settings/org.eclipse.jdt.core.prefs marker
+$ newer d/.settings/org.eclipse.jdt.core.prefs marker
+$ newer e/.settings/org.eclipse.jdt.core.prefs marker
+-$ exists f/.settings/org.eclipse.jdt.core.prefs
+$ newer g/.settings/org.eclipse.jdt.core.prefs marker
+
+# test ignore mode via command arg
+$ touch marker
+> eclipse jdt-mode=Ignore
+-$ exists a/.settings/org.eclipse.jdt.core.prefs
+$ newer marker b/.settings/org.eclipse.jdt.core.prefs
+$ newer marker c/.settings/org.eclipse.jdt.core.prefs
+$ newer marker d/.settings/org.eclipse.jdt.core.prefs
+$ newer marker e/.settings/org.eclipse.jdt.core.prefs
+-$ exists f/.settings/org.eclipse.jdt.core.prefs
+$ newer marker g/.settings/org.eclipse.jdt.core.prefs
+
+# test remove mode via command arg
+> eclipse jdt-mode=Remove
+-$ exists a/.settings/org.eclipse.jdt.core.prefs
+-$ exists b/.settings/org.eclipse.jdt.core.prefs
+-$ exists c/.settings/org.eclipse.jdt.core.prefs
+-$ exists d/.settings/org.eclipse.jdt.core.prefs
+-$ exists e/.settings/org.eclipse.jdt.core.prefs
+-$ exists f/.settings/org.eclipse.jdt.core.prefs
+-$ exists g/.settings/org.eclipse.jdt.core.prefs


### PR DESCRIPTION
Hi,

I'm so happy to see a reboot of this plugin.
I've been using it for driving ScalaIDE based development for over half a decade.
Since ScalaIDE is dead in the water it has also served to make the Java part of a project work in Metals/VSCode
https://github.com/scalameta/metals-feature-requests/issues/5

There it suffered from one issue.
![image](https://user-images.githubusercontent.com/677147/196505816-dd1d31b3-80e9-45bd-9e8b-7eed8f75abb8.png)

Which could be solved by inserting following file: `.settings/org.eclipse.jdt.core.prefs`
```
eclipse.preferences.version=1
org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
org.eclipse.jdt.core.compiler.compliance=1.8
org.eclipse.jdt.core.compiler.source=1.8
```

So far I simply checked this file in. That has work for quite a while, but I recently noticed that if the file exists RedHat Java LSP fills this file up with a ton of extra's, which messes up a diff.
![image](https://user-images.githubusercontent.com/677147/196505846-7fbac589-7ab5-4631-9162-5ca6d3e68f69.png)

Hence I felt that creating an extension on this plugin is the better way forward.

Concretely, what this PR does is
1. check if the file exist
2. if the file doesn't exit, write those 3 settings like for the other settings files
3. if the file did exist updated those 3 settings, but only write if there's updates

In both cases it matches the Java version as specified by the container.
I parse the container string, because in the context I need it it's readily available (without having to pass the environment) and it carries the required information.

I also considered whether some conditionality is needed, but because the information that gets written should always be valid, and it won't touch any other settings in the same prefs file I opted to just always apply it.

For lack of a formatter being defined in the repo I applied a local formatter on the changed parts.

Please let me know if something should be added or done differently?